### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
+++ b/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
@@ -94,7 +94,11 @@ namespace RazorPagesTestSample.Pages
 
         public static void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
+            if (!destFileName.StartsWith(fullDestDirPath)) {
+                throw new InvalidOperationException("Entry is outside the target dir: " + destFileName);
+            }
             entry.ExtractToFile(destFileName);
         }
     }


### PR DESCRIPTION
Fixes [https://github.com/hmntrathore/TechExcel-Accelerate-developer-productivity-with-GitHub-Copilot-and-Dev-Box/security/code-scanning/1](https://github.com/hmntrathore/TechExcel-Accelerate-developer-productivity-with-GitHub-Copilot-and-Dev-Box/security/code-scanning/1)

To fix the problem, we need to ensure that the output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. The steps to fix this are:

1. Use `Path.Combine(destinationDirectory, entry.FullName)` to determine the raw output path.
2. Use `Path.GetFullPath(..)` on the raw output path to resolve any directory traversal elements.
3. Use `Path.GetFullPath(destinationDirectory + Path.DirectorySeparatorChar)` to determine the fully resolved path of the destination directory.
4. Validate that the resolved output path `StartsWith` the resolved destination directory, aborting if this is not true.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
